### PR TITLE
fix: requeue upload on source CDN 5xx error with 10-minute delay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ src/curator/
 │   ├── config.py        # Configuration from environment
 │   ├── handler.py       # WebSocket business logic
 │   ├── auth.py, crypto.py, wcqs.py
-│   ├── errors.py        # DuplicateUploadError, HashLockError
+│   ├── errors.py        # DuplicateUploadError, HashLockError, StorageError, SourceCdnError
 │   ├── geocoding.py     # Reverse geocoding for location enrichment
 │   ├── task_enqueuer.py # Upload task enqueueing with rate limiting
 │   ├── rate_limiter.py  # Upload rate limiting with privileged user handling
@@ -113,6 +113,9 @@ Retry functionality allows users and admins to retry failed uploads. The current
 ### Redis Role
 Redis serves as both the Celery **broker** (task queue) and **result backend**. A Redis restart destroys all in-flight task data — tasks sitting in the broker queue are gone, but the database retains `status="queued"` records. The startup recovery system (`recovery.py`) reconciles this.
 
+### Worker Requeue Pattern
+`tasks.py` uses `_requeue_or_fail(self, upload_id, worker_id, DELAYS, exc)` to requeue or permanently fail on exhaustion. Each error type has its own delay list constant: `STORAGE_ERROR_DELAYS = [300, 600, 900]`, `HASH_LOCK_DELAYS = [60, 60, 60]`, `SOURCE_CDN_DELAYS = [600]`. To add a new requeue type: add a constant, add a `except NewError` handler in `process_one` (reset to `QUEUED`, re-raise), add a matching handler in `process_upload` calling `_requeue_or_fail`.
+
 ### Rate Limiting
 - Rate limits are fetched from `action=query&meta=userinfo&uiprop=ratelimits|rights` via `MediaWikiClient.get_user_rate_limits()` which returns `(ratelimits, rights)`
 - Each upload costs 2 edit API calls (SDC apply + null edit), so the edit limit is halved before comparing against the upload limit — the more restrictive of the two is used
@@ -124,6 +127,7 @@ Redis serves as both the Celery **broker** (task queue) and **result backend**. 
 
 ### commons.py (Upload Workflow)
 `commons.py` contains both the upload-to-Commons workflow (`upload_file_chunked`) and the image download function (`download_file`) which fetches from external CDNs (e.g., Mapillary/Facebook). Both download and upload chunk retries use `config.HTTP_RETRY_DELAYS` for escalating backoff but have separate retry loops — they differ in error handling and response processing.
+- `download_file` raises `SourceCdnError` (not `HTTPError`) when all retries are exhausted on a 5xx response — this triggers a task-level requeue. 4xx errors raise `HTTPError` directly and are treated as permanent failures.
 
 ### MediaWiki Client
 - `MediaWikiClient` class handles all Wikimedia Commons operations

--- a/src/curator/core/errors.py
+++ b/src/curator/core/errors.py
@@ -19,3 +19,9 @@ class StorageError(Exception):
     """Raised when the MediaWiki storage backend fails persistently"""
 
     pass
+
+
+class SourceCdnError(Exception):
+    """Raised when the image source CDN fails with a 5xx error after all download retries"""
+
+    pass

--- a/src/curator/mediawiki/commons.py
+++ b/src/curator/mediawiki/commons.py
@@ -8,7 +8,7 @@ import requests
 
 from curator.asyncapi import Label, Statement
 from curator.core.config import HTTP_RETRY_DELAYS, redis_client
-from curator.core.errors import DuplicateUploadError, HashLockError
+from curator.core.errors import DuplicateUploadError, HashLockError, SourceCdnError
 from curator.mediawiki.client import MediaWikiClient
 
 logger = logging.getLogger(__name__)
@@ -133,6 +133,12 @@ def download_file(
                     f"[{upload_id}/{batch_id}] Image download failed after "
                     f"{max_attempts}/{max_attempts} attempts: {e}"
                 )
+                if (
+                    isinstance(e, requests.exceptions.HTTPError)
+                    and e.response is not None
+                    and e.response.status_code >= 500
+                ):
+                    raise SourceCdnError(str(e)) from e
                 raise
             logger.warning(
                 f"[{upload_id}/{batch_id}] Image download "

--- a/src/curator/workers/ingest.py
+++ b/src/curator/workers/ingest.py
@@ -11,7 +11,12 @@ from curator.asyncapi import (
     TitleBlacklistedError,
 )
 from curator.core.crypto import decrypt_access_token
-from curator.core.errors import DuplicateUploadError, HashLockError, StorageError
+from curator.core.errors import (
+    DuplicateUploadError,
+    HashLockError,
+    SourceCdnError,
+    StorageError,
+)
 from curator.db.dal_uploads import (
     clear_upload_access_token,
     get_upload_request_by_id,
@@ -459,6 +464,16 @@ async def process_one(upload_id: int, edit_group_id: str) -> bool:
                     UploadStatus.DUPLICATE,
                     DuplicateError(message=str(e), links=e.duplicates),
                 )
+
+    except SourceCdnError:
+        logger.warning(
+            f"[{upload_id}/{batchid}] source CDN error, resetting status for requeue"
+        )
+        with get_session() as session:
+            update_upload_status(
+                session, upload_id=upload_id, status=UploadStatus.QUEUED
+            )
+        raise
 
     except StorageError:
         logger.warning(

--- a/src/curator/workers/tasks.py
+++ b/src/curator/workers/tasks.py
@@ -6,7 +6,7 @@ import os
 
 from celery import Task
 
-from curator.core.errors import HashLockError, StorageError
+from curator.core.errors import HashLockError, SourceCdnError, StorageError
 from curator.db.dal_uploads import update_upload_status
 from curator.db.engine import get_session
 from curator.db.models import UploadStatus
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 STORAGE_ERROR_DELAYS = [300, 600, 900]
 # Requeue delays in seconds for HashLockError retries: 1 min each
 HASH_LOCK_DELAYS = [60, 60, 60]
+# Requeue delay for source CDN 5xx errors: single 10-minute retry
+SOURCE_CDN_DELAYS = [600]
 
 # Create a single event loop per worker process
 _worker_loop = None
@@ -71,6 +73,13 @@ def process_upload(self, upload_id: int, edit_group_id: str) -> bool:
     try:
         result = loop.run_until_complete(process_one(upload_id, edit_group_id))
         return result
+    except SourceCdnError as e:
+        retry_num = self.request.retries
+        logger.warning(
+            f"[celery] [{upload_id}] [{worker_id}] source CDN error, requeueing "
+            f"(retry {retry_num + 1}/{len(SOURCE_CDN_DELAYS)}): {e}"
+        )
+        return _requeue_or_fail(self, upload_id, worker_id, SOURCE_CDN_DELAYS, e)
     except StorageError as e:
         retry_num = self.request.retries
         logger.warning(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,6 +8,7 @@ import pytest
 import requests.exceptions
 
 from curator.core.config import HTTP_RETRY_DELAYS
+from curator.core.errors import SourceCdnError
 from curator.mediawiki.commons import download_file
 
 MAX_DOWNLOAD_ATTEMPTS = len(HTTP_RETRY_DELAYS) + 1
@@ -74,10 +75,30 @@ def test_download_retries_on_http_error_then_succeeds(mocker):
     mock_sleep.assert_called_once_with(HTTP_RETRY_DELAYS[0])
 
 
-def test_download_raises_after_all_retries_on_http_error(mocker):
-    """504 on all attempts raises after all retries exhausted"""
+@pytest.mark.parametrize("status_code", [502, 504])
+def test_download_raises_source_cdn_error_after_all_retries_on_5xx(mocker, status_code):
+    """5xx (502, 504) on all attempts raises SourceCdnError after retries exhausted"""
     mocker.patch("curator.mediawiki.commons.time.sleep")
-    error = _make_http_error(504)
+    error = _make_http_error(status_code)
+    mocker.patch(
+        "curator.mediawiki.commons.requests.get",
+        side_effect=[
+            _make_response(mocker, http_error=error)
+            for _ in range(MAX_DOWNLOAD_ATTEMPTS)
+        ],
+    )
+
+    with NamedTemporaryFile() as temp_file:
+        with pytest.raises(SourceCdnError):
+            download_file(
+                "https://example.com/file.jpg", temp_file, upload_id=1, batch_id=2
+            )
+
+
+def test_download_raises_http_error_after_all_retries_on_4xx(mocker):
+    """4xx on all attempts raises HTTPError (not SourceCdnError) — not transient"""
+    mocker.patch("curator.mediawiki.commons.time.sleep")
+    error = _make_http_error(403)
     mocker.patch(
         "curator.mediawiki.commons.requests.get",
         side_effect=[
@@ -160,7 +181,7 @@ def test_download_logs_error_when_all_retries_exhausted(mocker, caplog):
         caplog.at_level(logging.ERROR, logger="curator.mediawiki.commons"),
         NamedTemporaryFile() as temp_file,
     ):
-        with pytest.raises(requests.exceptions.HTTPError):
+        with pytest.raises(SourceCdnError):
             download_file(
                 "https://example.com/file.jpg", temp_file, upload_id=1, batch_id=2
             )

--- a/tests/workers/test_worker_storage_error.py
+++ b/tests/workers/test_worker_storage_error.py
@@ -7,9 +7,14 @@ import pytest
 from mwoauth import AccessToken
 
 from curator.core.crypto import encrypt_access_token
-from curator.core.errors import HashLockError, StorageError
+from curator.core.errors import HashLockError, SourceCdnError, StorageError
 from curator.workers.ingest import process_one
-from curator.workers.tasks import HASH_LOCK_DELAYS, STORAGE_ERROR_DELAYS, process_upload
+from curator.workers.tasks import (
+    HASH_LOCK_DELAYS,
+    SOURCE_CDN_DELAYS,
+    STORAGE_ERROR_DELAYS,
+    process_upload,
+)
 
 _UPLOADSTASH_EXCEPTION_ERROR = (
     "uploadstash-exception: Could not store upload in the stash "
@@ -219,6 +224,97 @@ def test_process_upload_fails_permanently_when_hash_lock_exceeds_max_retries(
 
     with (
         patch("curator.workers.tasks.process_one", side_effect=HashLockError("locked")),
+        patch("curator.workers.tasks.get_session") as mock_get_session,
+        patch("curator.workers.tasks.update_upload_status", side_effect=capture_status),
+    ):
+        mock_get_session.return_value.__enter__ = lambda s: mock_session
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = process_upload._orig_run.__func__(mock_self, 1, "abc")
+
+    assert result is False
+    assert captured_status.get("status") == "failed"
+    mock_self.retry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_one_resets_to_queued_on_source_cdn_error(
+    mock_session, mock_isolated_site, upload_item, mock_mapillary_image
+):
+    """process_one resets status to queued and re-raises SourceCdnError for task-level requeue."""
+    captured_status = {}
+
+    def capture_status(session, upload_id, status, **kwargs):
+        captured_status["status"] = status
+
+    with (
+        patch(
+            "curator.workers.ingest.get_upload_request_by_id", return_value=upload_item
+        ),
+        patch(
+            "curator.workers.ingest.update_upload_status", side_effect=capture_status
+        ),
+        patch("curator.workers.ingest.MediaWikiClient") as mock_client_patch,
+        patch(
+            "curator.workers.ingest.upload_file_chunked",
+            side_effect=SourceCdnError("502 Bad Gateway"),
+        ),
+        patch("curator.workers.ingest.clear_upload_access_token"),
+        patch(
+            "curator.workers.ingest.MapillaryHandler.fetch_image_metadata",
+            new_callable=AsyncMock,
+            return_value=mock_mapillary_image,
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_client.check_title_blacklisted.return_value = (False, "")
+        mock_client_patch.return_value = mock_client
+
+        with pytest.raises(SourceCdnError):
+            await process_one(1, "test_edit_group_abc123")
+
+    assert captured_status.get("status") == "queued"
+
+
+def test_process_upload_requeues_with_10_min_delay_on_source_cdn_error():
+    """process_upload requeues SourceCdnError with a 10-minute delay."""
+    assert SOURCE_CDN_DELAYS == [600]
+
+    mock_self = MagicMock()
+    mock_self.max_retries = 1
+    mock_self.request.retries = 0
+    mock_self.retry.side_effect = Exception("retry scheduled")
+
+    with patch(
+        "curator.workers.tasks.process_one",
+        side_effect=SourceCdnError("Bad Gateway"),
+    ):
+        with pytest.raises(Exception, match="retry scheduled"):
+            process_upload._orig_run.__func__(mock_self, 1, "abc")
+
+    mock_self.retry.assert_called_once_with(
+        countdown=600, exc=mock_self.retry.call_args[1]["exc"]
+    )
+
+
+def test_process_upload_fails_permanently_after_source_cdn_retry_exhausted(
+    mock_session,
+):
+    """process_upload marks upload as FAILED after the single SourceCdnError retry."""
+    mock_self = MagicMock()
+    mock_self.max_retries = 1
+    mock_self.request.retries = len(SOURCE_CDN_DELAYS)
+
+    captured_status = {}
+
+    def capture_status(session, upload_id, status, **kwargs):
+        captured_status["status"] = status
+
+    with (
+        patch(
+            "curator.workers.tasks.process_one",
+            side_effect=SourceCdnError("502 Bad Gateway"),
+        ),
         patch("curator.workers.tasks.get_session") as mock_get_session,
         patch("curator.workers.tasks.update_upload_status", side_effect=capture_status),
     ):


### PR DESCRIPTION
When downloading images from the Mapillary/Facebook CDN, transient 5xx errors (502, 504) were causing uploads to be permanently marked as failed after exhausting the 4 per-download retries. These CDN errors are transient infrastructure failures, not permanent errors — the upload should be retried after a delay.

This adds `SourceCdnError` raised by `download_file` when all retries fail on a 5xx response. The error propagates through `process_one` (resetting status to `queued`) and is caught in `process_upload`, which requeues with a single 10-minute delay (`SOURCE_CDN_DELAYS = [600]`) using the existing `_requeue_or_fail` pattern. 4xx errors are unchanged — they remain permanent failures.