### PR TITLE
fix: gracefully handle WebSocket disconnect during server shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ Performance findings:
 
 ### AsyncAPI WebSocket Protocol
 - Union types `ClientMessage` and `ServerMessage` defined in `protocol.py`
+- Background streaming tasks that send on a closing WebSocket receive `AssertionError` (from `websockets.legacy.protocol._drain_helper`), not `WebSocketDisconnect` — detect a clean shutdown via `socket.client_state == WebSocketState.DISCONNECTED` (import from `starlette.websockets`)
 - 50+ auto-generated message types in `asyncapi/`
 - Two-phase upload process: creation phase (slices via `UPLOAD_SLICE`) → subscription phase (`SUBSCRIBE_BATCH`)
 - `UploadSliceAck` provides immediate item status updates to client

--- a/src/curator/core/handler.py
+++ b/src/curator/core/handler.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, cast
 import httpx
 from fastapi import WebSocketDisconnect
 from sqlmodel import Session
+from starlette.websockets import WebSocketState
 
 from curator.asyncapi import (
     BatchesListData,
@@ -856,8 +857,13 @@ class OptimizedBatchStreamer:
                 f"[ws] [resp] Stopping optimized batch streaming for {self.username}"
             )
         except Exception as e:
-            logger.error(f"[ws] [resp] Error in optimized batch streaming: {e}")
-            raise
+            if self.socket.client_state == WebSocketState.DISCONNECTED:
+                logger.info(
+                    f"[ws] [resp] Streaming stopped: WebSocket disconnected for {self.username}"
+                )
+            else:
+                logger.error(f"[ws] [resp] Error in optimized batch streaming: {e}")
+                raise
 
     async def stop_streaming(self):
         """Stop the streaming process."""

--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from starlette.websockets import WebSocketState
 
 from curator.asyncapi import BatchItem, BatchStats
 from curator.core.handler import OptimizedBatchStreamer
@@ -149,3 +150,33 @@ async def test_streamer_no_updates_on_paginated_page(mock_sender):
 
         # asyncio.sleep should NOT have been called (the loop was bypassed)
         mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_streamer_swallows_error_on_websocket_disconnect(mock_sender):
+    streamer = OptimizedBatchStreamer(mock_sender, "testuser")
+    mock_sender.client_state = WebSocketState.DISCONNECTED
+    mock_sender.send_batches_list.side_effect = AssertionError
+
+    with (
+        patch("curator.core.handler.get_batches"),
+        patch("curator.core.handler.count_batches", return_value=0),
+        patch("curator.core.handler.get_latest_update_time", return_value=None),
+    ):
+        # Should not raise — disconnected WebSocket is a clean exit
+        await streamer.start_streaming(userid="u1")
+
+
+@pytest.mark.asyncio
+async def test_streamer_reraises_error_on_connected_websocket(mock_sender):
+    streamer = OptimizedBatchStreamer(mock_sender, "testuser")
+    mock_sender.client_state = WebSocketState.CONNECTED
+    mock_sender.send_batches_list.side_effect = RuntimeError("unexpected")
+
+    with (
+        patch("curator.core.handler.get_batches"),
+        patch("curator.core.handler.count_batches", return_value=0),
+        patch("curator.core.handler.get_latest_update_time", return_value=None),
+    ):
+        with pytest.raises(RuntimeError, match="unexpected"):
+            await streamer.start_streaming(userid="u1")


### PR DESCRIPTION
During server shutdown, `OptimizedBatchStreamer` background tasks try to send on a closing WebSocket and hit an `AssertionError` deep in `websockets.legacy.protocol._drain_helper`. This surfaces as an unhandled task exception rather than a clean exit.

Detect the disconnect via `socket.client_state == WebSocketState.DISCONNECTED` — log at INFO and exit quietly. Real errors on a still-connected socket still log at ERROR and re-raise. Added tests for both branches.