### PR TITLE
fix: correct fair queue task dispatch and worker startup

### DIFF
--- a/src/curator/admin.py
+++ b/src/curator/admin.py
@@ -194,7 +194,7 @@ async def admin_retry_uploads(
     tasks_to_update = []
     for upload_id in reset_ids:
         task_result = process_upload.apply_async(
-            args=[upload_id, edit_group_id], queue=QUEUE_NORMAL
+            args=[upload_id, edit_group_id, user["userid"]], queue=QUEUE_NORMAL
         )
         task_id = task_result.id
         if isinstance(task_id, str):

--- a/src/curator/core/task_enqueuer.py
+++ b/src/curator/core/task_enqueuer.py
@@ -1,7 +1,7 @@
 """Task enqueuing utilities with rate limiting.
 
 Provides a unified interface for enqueueing upload tasks with proper
-rate limiting. All uploads go to QUEUE_NORMAL.
+rate limiting. Each user's uploads go to a dedicated per-user queue.
 """
 
 import asyncio
@@ -18,7 +18,7 @@ from curator.core.rate_limiter import (
 from curator.db.engine import get_session
 from curator.db.models import UploadRequest
 from curator.mediawiki.client import MediaWikiClient
-from curator.workers.celery import QUEUE_NORMAL
+from curator.workers.celery import QUEUE_USER_PREFIX, register_user_queue
 from curator.workers.tasks import process_upload
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,9 @@ async def enqueue_uploads(
         client=client,
     )
 
+    user_queue = f"{QUEUE_USER_PREFIX}{userid}"
+    register_user_queue(userid)
+
     enqueued_task_ids: list[str] = []
     upload_id_to_task_id: dict[int, str] = {}
 
@@ -45,9 +48,9 @@ async def enqueue_uploads(
         delay = await asyncio.to_thread(get_next_upload_delay, userid, rate_limit)
 
         task_result = process_upload.apply_async(
-            args=[upload_id, edit_group_id],
+            args=[upload_id, edit_group_id, userid],
             countdown=delay,
-            queue=QUEUE_NORMAL,
+            queue=user_queue,
         )
 
         task_id = task_result.id
@@ -64,10 +67,8 @@ async def enqueue_uploads(
                     .where(col(UploadRequest.id) == upload_id)
                     .values(celery_task_id=task_id)
                 )
-            session.flush()
-
     logger.info(
-        f"[task_enqueuer] Enqueued {len(enqueued_task_ids)} uploads to queue {QUEUE_NORMAL}"
+        f"[task_enqueuer] Enqueued {len(enqueued_task_ids)} uploads to queue {user_queue}"
     )
 
     return enqueued_task_ids

--- a/src/curator/core/task_enqueuer.py
+++ b/src/curator/core/task_enqueuer.py
@@ -39,7 +39,7 @@ async def enqueue_uploads(
     )
 
     user_queue = f"{QUEUE_USER_PREFIX}{userid}"
-    register_user_queue(userid)
+    await asyncio.to_thread(register_user_queue, userid)
 
     enqueued_task_ids: list[str] = []
     upload_id_to_task_id: dict[int, str] = {}
@@ -47,7 +47,8 @@ async def enqueue_uploads(
     for upload_id in upload_ids:
         delay = await asyncio.to_thread(get_next_upload_delay, userid, rate_limit)
 
-        task_result = process_upload.apply_async(
+        task_result = await asyncio.to_thread(
+            process_upload.apply_async,
             args=[upload_id, edit_group_id, userid],
             countdown=delay,
             queue=user_queue,

--- a/src/curator/db/dal_uploads.py
+++ b/src/curator/db/dal_uploads.py
@@ -130,6 +130,15 @@ def count_all_upload_requests(
     return session.exec(query).one()
 
 
+def count_active_uploads_for_user(session: Session, userid: str) -> int:
+    """Count uploads with queued or in_progress status for a user."""
+    query = select(func.count(col(UploadRequest.id))).where(
+        col(UploadRequest.userid) == userid,
+        col(UploadRequest.status).in_([UploadStatus.QUEUED, UploadStatus.IN_PROGRESS]),
+    )
+    return session.exec(query).one()
+
+
 def cancel_upload_requests(session: Session, ids: list[int]) -> int:
     """Cancel upload requests by ID if they are queued or in_progress."""
     if not ids:

--- a/src/curator/workers/celery.py
+++ b/src/curator/workers/celery.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from typing import cast
 
 from celery import Celery
 from celery.signals import (
@@ -25,9 +26,34 @@ from curator.core.config import (
     CELERY_CONCURRENCY,
     CELERY_MAXIMUM_WAIT_TIME,
     CELERY_TASKS_PER_WORKER,
+    redis_client,
 )
+from curator.db.dal_uploads import count_active_uploads_for_user
+from curator.db.engine import get_session
 
 QUEUE_NORMAL = "uploads-normal"
+QUEUE_USER_PREFIX = "uploads-"
+ACTIVE_USER_QUEUES_KEY = "curator:active_user_queues"
+
+
+def register_user_queue(userid: str) -> None:
+    """Register per-user upload queue and notify running workers if new."""
+    queue_name = f"{QUEUE_USER_PREFIX}{userid}"
+    if redis_client.sadd(ACTIVE_USER_QUEUES_KEY, queue_name) == 1:
+        app.control.add_consumer(queue_name, reply=False)
+
+
+def cleanup_user_queue_if_empty(userid: str) -> None:
+    """Remove user queue when no active uploads remain."""
+    try:
+        with get_session() as session:
+            if count_active_uploads_for_user(session, userid) == 0:
+                queue_name = f"{QUEUE_USER_PREFIX}{userid}"
+                redis_client.srem(ACTIVE_USER_QUEUES_KEY, queue_name)
+                app.control.cancel_consumer(queue_name, reply=False)
+    except Exception:
+        logger.exception(f"[celery] Failed to clean up queue for user {userid}")
+
 
 app = Celery("curator")
 app.conf.update(
@@ -64,14 +90,13 @@ task_counter = multiprocessing.Value("i", 0)
 
 
 @worker_init.connect
-def on_worker_init(**kwargs):
-    """Configure logging for Celery worker processes."""
-    # Suppress httpx INFO logs (HTTP Request messages)
+def on_worker_init(**kwargs) -> None:
+    """Configure logging on worker startup."""
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 @task_postrun.connect
-def on_task_postrun(**kwargs):
+def on_task_postrun(task=None, args=None, **kwargs) -> None:
     with task_counter.get_lock():
         task_counter.value += 1
         if task_counter.value == CELERY_TASKS_PER_WORKER:
@@ -79,6 +104,14 @@ def on_task_postrun(**kwargs):
                 f"Worker reached task limit ({CELERY_TASKS_PER_WORKER}). Initiating shutdown."
             )
             os.kill(os.getppid(), signal.SIGTERM)
+
+    if (
+        task
+        and task.name == "curator.workers.tasks.process_upload"
+        and args
+        and len(args) >= 3
+    ):
+        cleanup_user_queue_if_empty(args[2])
 
 
 @worker_ready.connect
@@ -160,7 +193,10 @@ def start():
     if sys.platform == "darwin":
         os.environ.setdefault("NO_PROXY", "*")
 
-    queues = QUEUE_NORMAL
+    active_user_queues = list(
+        cast(set[str], redis_client.smembers(ACTIVE_USER_QUEUES_KEY))
+    )
+    queues = ",".join([QUEUE_NORMAL] + active_user_queues)
 
     app.worker_main(
         [

--- a/src/curator/workers/celery.py
+++ b/src/curator/workers/celery.py
@@ -49,8 +49,8 @@ def cleanup_user_queue_if_empty(userid: str) -> None:
         with get_session() as session:
             if count_active_uploads_for_user(session, userid) == 0:
                 queue_name = f"{QUEUE_USER_PREFIX}{userid}"
-                redis_client.srem(ACTIVE_USER_QUEUES_KEY, queue_name)
-                app.control.cancel_consumer(queue_name, reply=False)
+                if redis_client.srem(ACTIVE_USER_QUEUES_KEY, queue_name) == 1:
+                    app.control.cancel_consumer(queue_name, reply=False)
     except Exception:
         logger.exception(f"[celery] Failed to clean up queue for user {userid}")
 

--- a/src/curator/workers/tasks.py
+++ b/src/curator/workers/tasks.py
@@ -62,7 +62,7 @@ def _requeue_or_fail(
     retry_backoff_max=600,
     retry_jitter=True,
 )
-def process_upload(self, upload_id: int, edit_group_id: str) -> bool:
+def process_upload(self, upload_id: int, edit_group_id: str, userid: str) -> bool:
     """
     Process a single upload request
     """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -430,6 +430,7 @@ def mock_external_calls(mocker, request):
     mocker.patch(
         "curator.workers.ingest.build_statements_from_mapillary_image", return_value=[]
     )
+    mocker.patch("curator.core.task_enqueuer.register_user_queue")
 
 
 @pytest.fixture

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -222,12 +222,13 @@ async def test_admin_retry_uploads_success(mock_session, patch_get_session):
         assert mock_task.call_count == 3
         # Check that all calls have the correct structure
         for call in mock_task.call_args_list:
-            assert len(call[1]["args"]) == 2  # upload_id and edit_group_id
+            assert len(call[1]["args"]) == 3  # upload_id, edit_group_id, userid
             assert isinstance(call[1]["args"][0], int)  # upload_id is an integer
             assert isinstance(call[1]["args"][1], str)  # edit_group_id is a string
             assert (
                 call[1]["args"][1] == "adminretry123"
             )  # Uses new batch's edit_group_id
+            assert isinstance(call[1]["args"][2], str)  # userid is a string
             assert call[1]["queue"] == QUEUE_NORMAL
         # Verify the correct upload_ids were called
         upload_ids = {call[1]["args"][0] for call in mock_task.call_args_list}

--- a/tests/test_batched_upload.py
+++ b/tests/test_batched_upload.py
@@ -1,12 +1,11 @@
 """Tests for batch upload operations."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from curator.asyncapi import UploadItem, UploadSliceAckItem, UploadSliceData
 from curator.core.rate_limiter import RateLimitInfo
-from curator.workers.celery import QUEUE_NORMAL
 
 
 @pytest.mark.asyncio
@@ -28,7 +27,6 @@ async def test_create_batch(mocker, handler_instance, mock_sender, mock_session)
 
 @pytest.mark.asyncio
 async def test_upload_slice(mocker, handler_instance, mock_sender, mock_session):
-    # Mock batch with edit_group_id
     mock_batch = mocker.MagicMock()
     mock_batch.id = 123
     mock_batch.edit_group_id = "abc123def456"
@@ -44,12 +42,12 @@ async def test_upload_slice(mocker, handler_instance, mock_sender, mock_session)
             "curator.core.task_enqueuer.get_rate_limit_for_batch"
         ) as mock_get_rate_limit,
         patch("curator.core.task_enqueuer.get_next_upload_delay") as mock_get_delay,
+        patch("curator.core.task_enqueuer.register_user_queue"),
     ):
-        # Mock both delay and apply_async
-        mock_process_upload.delay = mocker.MagicMock()
-        mock_process_upload.apply_async = mocker.MagicMock()
+        mock_process_upload.apply_async = mocker.MagicMock(
+            return_value=MagicMock(id="task-1")
+        )
 
-        # Mock rate limiter to return privileged user (no delay)
         mock_get_rate_limit.return_value = RateLimitInfo(
             uploads_per_period=999, period_seconds=1
         )
@@ -71,19 +69,14 @@ async def test_upload_slice(mocker, handler_instance, mock_sender, mock_session)
         await handler_instance.upload_slice(data)
 
         mock_create_reqs.assert_called_once()
-        # Check that process_upload.apply_async was called once
         assert mock_process_upload.apply_async.call_count == 1
 
-        # Check the call arguments (apply_async uses kwargs)
         call_kwargs = mock_process_upload.apply_async.call_args[1]
-        assert call_kwargs["args"][0] == 1  # First arg is upload_id
-        assert len(call_kwargs["args"]) == 2  # Called with 2 args
-        assert isinstance(
-            call_kwargs["args"][1], str
-        )  # Second arg is edit_group_id string
-        assert len(call_kwargs["args"][1]) == 12  # edit_group_id is 12 characters
-        assert call_kwargs["args"][1] == "abc123def456"  # Uses batch's edit_group_id
-        assert call_kwargs["queue"] == QUEUE_NORMAL
+        assert call_kwargs["args"][0] == 1
+        assert len(call_kwargs["args"]) == 3
+        assert call_kwargs["args"][1] == "abc123def456"
+        assert call_kwargs["args"][2] == "user123"
+        assert call_kwargs["queue"] == "uploads-user123"
 
         mock_sender.send_upload_slice_ack.assert_called_once_with(
             data=[UploadSliceAckItem(id="img1", status="queued")], sliceid=0
@@ -94,7 +87,6 @@ async def test_upload_slice(mocker, handler_instance, mock_sender, mock_session)
 async def test_upload_slice_multiple_items(
     mocker, handler_instance, mock_sender, mock_session
 ):
-    # Mock batch with edit_group_id
     mock_batch = mocker.MagicMock()
     mock_batch.id = 123
     mock_batch.edit_group_id = "xyz789uvw012"
@@ -110,12 +102,12 @@ async def test_upload_slice_multiple_items(
             "curator.core.task_enqueuer.get_rate_limit_for_batch"
         ) as mock_get_rate_limit,
         patch("curator.core.task_enqueuer.get_next_upload_delay") as mock_get_delay,
+        patch("curator.core.task_enqueuer.register_user_queue"),
     ):
-        # Mock both delay and apply_async
-        mock_process_upload.delay = mocker.MagicMock()
-        mock_process_upload.apply_async = mocker.MagicMock()
+        mock_process_upload.apply_async = mocker.MagicMock(
+            return_value=MagicMock(id="task-1")
+        )
 
-        # Mock rate limiter to return privileged user (no delay)
         mock_get_rate_limit.return_value = RateLimitInfo(
             uploads_per_period=999, period_seconds=1
         )
@@ -144,17 +136,14 @@ async def test_upload_slice_multiple_items(
         await handler_instance.upload_slice(data)
 
         mock_create_reqs.assert_called_once()
-        # Verify process_upload.apply_async was called twice
         assert mock_process_upload.apply_async.call_count == 2
-        # Verify both calls have queue parameter and use batch's edit_group_id
         for call in mock_process_upload.apply_async.call_args_list:
-            assert call[1]["queue"] == QUEUE_NORMAL
-            assert call[1]["args"][1] == "xyz789uvw012"  # Uses batch's edit_group_id
+            assert call[1]["queue"] == "uploads-user123"
+            assert call[1]["args"][1] == "xyz789uvw012"
+            assert call[1]["args"][2] == "user123"
 
-        # Verify send_upload_slice_ack was called with data and sliceid
         mock_sender.send_upload_slice_ack.assert_called_once()
         call_args = mock_sender.send_upload_slice_ack.call_args
-        # Check both positional and keyword arguments
         if len(call_args[0]) > 0:
             data_arg = call_args[0][0]
         else:

--- a/tests/test_task_enqueuer.py
+++ b/tests/test_task_enqueuer.py
@@ -1,0 +1,98 @@
+"""Tests for task enqueuer queue routing and user queue registration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mwoauth import AccessToken
+
+from curator.core.rate_limiter import RateLimitInfo
+
+
+@pytest.fixture
+def access_token():
+    return AccessToken("key", "secret")
+
+
+@pytest.fixture
+def rate_limit():
+    return RateLimitInfo(uploads_per_period=999, period_seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_enqueues_to_user_queue(access_token, rate_limit):
+    with (
+        patch("curator.core.task_enqueuer.process_upload") as mock_process_upload,
+        patch(
+            "curator.core.task_enqueuer.get_rate_limit_for_batch",
+            return_value=rate_limit,
+        ),
+        patch("curator.core.task_enqueuer.get_next_upload_delay", return_value=0.0),
+        patch("curator.core.task_enqueuer.register_user_queue"),
+        patch("curator.core.task_enqueuer.get_session"),
+    ):
+        mock_process_upload.apply_async.return_value = MagicMock(id="task-1")
+
+        from curator.core.task_enqueuer import enqueue_uploads
+
+        await enqueue_uploads(
+            upload_ids=[1],
+            edit_group_id="eg1",
+            userid="user123",
+            access_token=access_token,
+        )
+
+        call_kwargs = mock_process_upload.apply_async.call_args[1]
+        assert call_kwargs["queue"] == "uploads-user123"
+
+
+@pytest.mark.asyncio
+async def test_calls_register_user_queue(access_token, rate_limit):
+    with (
+        patch("curator.core.task_enqueuer.process_upload") as mock_process_upload,
+        patch(
+            "curator.core.task_enqueuer.get_rate_limit_for_batch",
+            return_value=rate_limit,
+        ),
+        patch("curator.core.task_enqueuer.get_next_upload_delay", return_value=0.0),
+        patch("curator.core.task_enqueuer.register_user_queue") as mock_register,
+        patch("curator.core.task_enqueuer.get_session"),
+    ):
+        mock_process_upload.apply_async.return_value = MagicMock(id="task-1")
+
+        from curator.core.task_enqueuer import enqueue_uploads
+
+        await enqueue_uploads(
+            upload_ids=[1],
+            edit_group_id="eg1",
+            userid="user123",
+            access_token=access_token,
+        )
+
+        mock_register.assert_called_once_with("user123")
+
+
+@pytest.mark.asyncio
+async def test_passes_userid_as_task_arg(access_token, rate_limit):
+    with (
+        patch("curator.core.task_enqueuer.process_upload") as mock_process_upload,
+        patch(
+            "curator.core.task_enqueuer.get_rate_limit_for_batch",
+            return_value=rate_limit,
+        ),
+        patch("curator.core.task_enqueuer.get_next_upload_delay", return_value=0.0),
+        patch("curator.core.task_enqueuer.register_user_queue"),
+        patch("curator.core.task_enqueuer.get_session"),
+    ):
+        mock_process_upload.apply_async.return_value = MagicMock(id="task-1")
+
+        from curator.core.task_enqueuer import enqueue_uploads
+
+        await enqueue_uploads(
+            upload_ids=[1],
+            edit_group_id="eg1",
+            userid="user123",
+            access_token=access_token,
+        )
+
+        call_kwargs = mock_process_upload.apply_async.call_args[1]
+        assert call_kwargs["args"] == [1, "eg1", "user123"]

--- a/tests/test_ws_handler_operations.py
+++ b/tests/test_ws_handler_operations.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from curator.asyncapi import RetryUploads
-from curator.workers.celery import QUEUE_NORMAL
 
 
 @pytest.mark.asyncio
@@ -41,17 +40,18 @@ async def test_retry_uploads_success(mocker, handler_instance):
             "curator.core.task_enqueuer.get_rate_limit_for_batch"
         ) as mock_get_rate_limit,
         patch("curator.core.task_enqueuer.get_next_upload_delay") as mock_get_delay,
+        patch("curator.core.task_enqueuer.register_user_queue"),
     ):
         mock_reset.return_value = ([1, 2], "newbatch123", 456)
         mock_get_rate_limit.return_value = mocker.MagicMock()
         mock_get_delay.return_value = 0.0
+
         await handler_instance.retry_uploads(123)
 
         mock_reset.assert_called_once()
         assert mock_process_upload.apply_async.call_count == 2
-        # Check that calls were made with queue parameter and new batch's edit_group_id
         for call in mock_process_upload.apply_async.call_args_list:
-            assert call[1]["queue"] == QUEUE_NORMAL
+            assert call[1]["queue"] == "uploads-user123"
             assert call[1]["args"][1] == "newbatch123"
 
 
@@ -113,6 +113,7 @@ async def test_retry_uploads_enqueues_with_edit_group_id(mocker, handler_instanc
             "curator.core.task_enqueuer.get_rate_limit_for_batch"
         ) as mock_get_rate_limit,
         patch("curator.core.task_enqueuer.get_next_upload_delay") as mock_get_delay,
+        patch("curator.core.task_enqueuer.register_user_queue"),
     ):
         mock_reset.return_value = ([1, 2], "newbatch456", 789)
         mock_get_rate_limit.return_value = mocker.MagicMock()
@@ -125,6 +126,7 @@ async def test_retry_uploads_enqueues_with_edit_group_id(mocker, handler_instanc
         upload_ids = {call[1]["args"][0] for call in calls}
         assert upload_ids == {1, 2}
         for call in calls:
-            assert len(call[1]["args"]) == 2
+            assert len(call[1]["args"]) == 3
             assert call[1]["args"][1] == "newbatch456"
-            assert call[1]["queue"] == QUEUE_NORMAL
+            assert call[1]["args"][2] == "user123"
+            assert call[1]["queue"] == "uploads-user123"

--- a/tests/workers/test_fair_queue.py
+++ b/tests/workers/test_fair_queue.py
@@ -1,0 +1,110 @@
+"""Tests for fair queue registration and worker lifecycle."""
+
+from curator.workers.celery import (
+    cleanup_user_queue_if_empty,
+    on_task_postrun,
+    register_user_queue,
+    start,
+)
+
+
+def test_start_includes_active_user_queues(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_redis.smembers.return_value = {"uploads-user1", "uploads-user2"}
+    mock_app = mocker.patch("curator.workers.celery.app")
+
+    start()
+
+    call_args = mock_app.worker_main.call_args[0][0]
+    queues_arg = next(a for a in call_args if a.startswith("--queues="))
+    queues = set(queues_arg.removeprefix("--queues=").split(","))
+    assert queues == {"uploads-normal", "uploads-user1", "uploads-user2"}
+
+
+def test_start_no_active_user_queues(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_redis.smembers.return_value = set()
+    mock_app = mocker.patch("curator.workers.celery.app")
+
+    start()
+
+    call_args = mock_app.worker_main.call_args[0][0]
+    queues_arg = next(a for a in call_args if a.startswith("--queues="))
+    assert queues_arg == "--queues=uploads-normal"
+
+
+def test_register_user_queue_new(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_redis.sadd.return_value = 1
+    mock_app = mocker.patch("curator.workers.celery.app")
+
+    register_user_queue("user42")
+
+    mock_redis.sadd.assert_called_once_with(
+        "curator:active_user_queues", "uploads-user42"
+    )
+    mock_app.control.add_consumer.assert_called_once_with("uploads-user42", reply=False)
+
+
+def test_register_user_queue_existing(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_redis.sadd.return_value = 0
+    mock_app = mocker.patch("curator.workers.celery.app")
+
+    register_user_queue("user42")
+
+    mock_app.control.add_consumer.assert_not_called()
+
+
+def test_task_postrun_triggers_cleanup_for_process_upload(mocker):
+    mock_cleanup = mocker.patch("curator.workers.celery.cleanup_user_queue_if_empty")
+    mocker.patch("curator.workers.celery.task_counter")
+
+    mock_task = mocker.MagicMock()
+    mock_task.name = "curator.workers.tasks.process_upload"
+    on_task_postrun(task=mock_task, args=[1, "eg1", "user42"])
+
+    mock_cleanup.assert_called_once_with("user42")
+
+
+def test_task_postrun_skips_cleanup_for_other_tasks(mocker):
+    mock_cleanup = mocker.patch("curator.workers.celery.cleanup_user_queue_if_empty")
+    mocker.patch("curator.workers.celery.task_counter")
+
+    mock_task = mocker.MagicMock()
+    mock_task.name = "curator.workers.tasks.some_other_task"
+    on_task_postrun(task=mock_task, args=[1])
+
+    mock_cleanup.assert_not_called()
+
+
+def test_cleanup_user_queue_removes_when_empty(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_app = mocker.patch("curator.workers.celery.app")
+    mocker.patch(
+        "curator.workers.celery.count_active_uploads_for_user",
+        return_value=0,
+    )
+
+    cleanup_user_queue_if_empty("user42")
+
+    mock_redis.srem.assert_called_once_with(
+        "curator:active_user_queues", "uploads-user42"
+    )
+    mock_app.control.cancel_consumer.assert_called_once_with(
+        "uploads-user42", reply=False
+    )
+
+
+def test_cleanup_user_queue_skips_when_uploads_remain(mocker):
+    mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_app = mocker.patch("curator.workers.celery.app")
+    mocker.patch(
+        "curator.workers.celery.count_active_uploads_for_user",
+        return_value=3,
+    )
+
+    cleanup_user_queue_if_empty("user42")
+
+    mock_redis.srem.assert_not_called()
+    mock_app.control.cancel_consumer.assert_not_called()

--- a/tests/workers/test_fair_queue.py
+++ b/tests/workers/test_fair_queue.py
@@ -80,6 +80,7 @@ def test_task_postrun_skips_cleanup_for_other_tasks(mocker):
 
 def test_cleanup_user_queue_removes_when_empty(mocker):
     mock_redis = mocker.patch("curator.workers.celery.redis_client")
+    mock_redis.srem.return_value = 1
     mock_app = mocker.patch("curator.workers.celery.app")
     mocker.patch(
         "curator.workers.celery.count_active_uploads_for_user",

--- a/tests/workers/test_worker_storage_error.py
+++ b/tests/workers/test_worker_storage_error.py
@@ -131,7 +131,7 @@ def test_process_upload_fails_permanently_when_celery_max_retries_exceeded(
         mock_get_session.return_value.__enter__ = lambda s: mock_session
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = process_upload._orig_run.__func__(mock_self, 1, "abc")
+        result = process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
     assert result is False
     assert captured_status.get("status") == "failed"
@@ -153,7 +153,7 @@ def test_process_upload_requeues_with_escalating_delays_on_storage_error():
             side_effect=StorageError(_UPLOADSTASH_EXCEPTION_ERROR),
         ):
             with pytest.raises(Exception, match="retry scheduled"):
-                process_upload._orig_run.__func__(mock_self, 1, "abc")
+                process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
         mock_self.retry.assert_called_once_with(
             countdown=expected_delay, exc=mock_self.retry.call_args[1]["exc"]
@@ -181,7 +181,7 @@ def test_process_upload_fails_permanently_after_max_storage_retries(mock_session
         mock_get_session.return_value.__enter__ = lambda s: mock_session
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = process_upload._orig_run.__func__(mock_self, 1, "abc")
+        result = process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
     assert result is False
     assert captured_status.get("status") == "failed"
@@ -202,7 +202,7 @@ def test_process_upload_requeues_on_hash_lock_error():
             "curator.workers.tasks.process_one", side_effect=HashLockError("locked")
         ):
             with pytest.raises(Exception, match="retry scheduled"):
-                process_upload._orig_run.__func__(mock_self, 1, "abc")
+                process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
         mock_self.retry.assert_called_once_with(
             countdown=expected_delay, exc=mock_self.retry.call_args[1]["exc"]
@@ -230,7 +230,7 @@ def test_process_upload_fails_permanently_when_hash_lock_exceeds_max_retries(
         mock_get_session.return_value.__enter__ = lambda s: mock_session
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = process_upload._orig_run.__func__(mock_self, 1, "abc")
+        result = process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
     assert result is False
     assert captured_status.get("status") == "failed"
@@ -290,7 +290,7 @@ def test_process_upload_requeues_with_10_min_delay_on_source_cdn_error():
         side_effect=SourceCdnError("Bad Gateway"),
     ):
         with pytest.raises(Exception, match="retry scheduled"):
-            process_upload._orig_run.__func__(mock_self, 1, "abc")
+            process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
     mock_self.retry.assert_called_once_with(
         countdown=600, exc=mock_self.retry.call_args[1]["exc"]
@@ -321,7 +321,7 @@ def test_process_upload_fails_permanently_after_source_cdn_retry_exhausted(
         mock_get_session.return_value.__enter__ = lambda s: mock_session
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
-        result = process_upload._orig_run.__func__(mock_self, 1, "abc")
+        result = process_upload._orig_run.__func__(mock_self, 1, "abc", "user42")
 
     assert result is False
     assert captured_status.get("status") == "failed"


### PR DESCRIPTION
Three bugs fixed in the fair queue implementation:

1. `process_upload` task accepted 2 args but was dispatched with 3 (upload_id, edit_group_id, userid). Every task invocation raised `TypeError`. Added `userid: str` as third parameter. Admin retry updated to pass userid in lockstep.

2. `cleanup_user_queue_if_empty` ran a DB query in a signal handler with no error handling. A DB failure would raise an unhandled exception, leaving stale queue entries in Redis. Wrapped in try/except with logging.

3. Workers started with `--queues=uploads-normal` only. Tasks already enqueued in per-user queues before worker start were never consumed. `on_worker_init` tried to fix this via `add_consumer` broadcast but fired before child processes forked — messages dropped silently. Fixed `start()` to read active user queues from Redis and include them in `--queues` at startup.

Also removed redundant `session.flush()` from `task_enqueuer.py` and cleaned up `create=True` from test patches where the symbol already exists.