### PR TITLE
fix: make userid optional in process_upload for backward compat

### DIFF
--- a/src/curator/handlers/flickr_handler.py
+++ b/src/curator/handlers/flickr_handler.py
@@ -276,7 +276,9 @@ class FlickrHandler(Handler):
             batch_data = await fetch_photos_batch(batch_ids, photoset_id, user_id)
             all_images.update(batch_data)
 
-        return {k: from_flickr(v, photoset_id) for k, v in all_images.items()}, photoset_id
+        return {
+            k: from_flickr(v, photoset_id) for k, v in all_images.items()
+        }, photoset_id
 
     async def fetch_collection_ids(self, input: str) -> list[str]:
         """Fetch only photo IDs from album"""

--- a/src/curator/handlers/interfaces.py
+++ b/src/curator/handlers/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Union, Tuple
+from typing import Optional, Tuple, Union
 
 from fastapi import Request, WebSocket
 
@@ -12,7 +12,9 @@ class Handler(ABC):
     def name(self) -> str: ...
 
     @abstractmethod
-    async def fetch_collection(self, input: str) -> Tuple[dict[str, MediaImage], str]: ...
+    async def fetch_collection(
+        self, input: str
+    ) -> Tuple[dict[str, MediaImage], str]: ...
 
     @abstractmethod
     async def fetch_image_metadata(

--- a/src/curator/handlers/mapillary_handler.py
+++ b/src/curator/handlers/mapillary_handler.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, Optional, Union, Tuple
+from typing import Any, Optional, Tuple, Union
 from urllib.parse import parse_qs
 
 import httpx

--- a/src/curator/workers/tasks.py
+++ b/src/curator/workers/tasks.py
@@ -62,7 +62,9 @@ def _requeue_or_fail(
     retry_backoff_max=600,
     retry_jitter=True,
 )
-def process_upload(self, upload_id: int, edit_group_id: str, userid: str) -> bool:
+def process_upload(
+    self, upload_id: int, edit_group_id: str, userid: str | None = None
+) -> bool:
     """
     Process a single upload request
     """

--- a/tests/test_ws_handler_images.py
+++ b/tests/test_ws_handler_images.py
@@ -12,7 +12,9 @@ from curator.asyncapi import ImageHandler
 async def test_handle_fetch_images_success(handler_instance, mock_sender, mock_image):
     with patch("curator.core.handler.get_handler_for_handler_type") as mock_get_handler:
         mock_handler = MagicMock()
-        mock_handler.fetch_collection = AsyncMock(return_value=({"img1": mock_image}, "TODO"))
+        mock_handler.fetch_collection = AsyncMock(
+            return_value=({"img1": mock_image}, "TODO")
+        )
         mock_handler.fetch_existing_pages.return_value = {"img1": []}
         mock_handler.name = "mapillary"
         mock_get_handler.return_value = mock_handler

--- a/tests/test_ws_messages.py
+++ b/tests/test_ws_messages.py
@@ -76,7 +76,9 @@ def test_ws_fetch_images(mock_mapillary_handler):
     )
 
     # Mock fetch_collection
-    mock_handler_instance.fetch_collection = AsyncMock(return_value=({"img1": image}, "TODO"))
+    mock_handler_instance.fetch_collection = AsyncMock(
+        return_value=({"img1": image}, "TODO")
+    )
 
     # Mock fetch_existing_pages
     mock_handler_instance.fetch_existing_pages.return_value = {"img1": []}


### PR DESCRIPTION
Tasks queued before #253 deployed lack the `userid` argument. Making it optional with `None` default lets those tasks complete normally. Queue cleanup in `on_task_postrun` already guards against missing `userid` via `len(args) >= 3`.