### PR TITLE
fix: append Z suffix to UTC datetime fields and enforce UTC in models

### DIFF
--- a/src/curator/core/handler.py
+++ b/src/curator/core/handler.py
@@ -561,8 +561,8 @@ class Handler:
                     exclude_from_date_category=p.exclude_from_date_category,
                     handler=p.handler,
                     is_default=p.is_default,
-                    created_at=p.created_at.isoformat(),
-                    updated_at=p.updated_at.isoformat(),
+                    created_at=p.created_at.isoformat() + "Z",
+                    updated_at=p.updated_at.isoformat() + "Z",
                 )
                 for p in presets
             ]

--- a/src/curator/db/dal_batches.py
+++ b/src/curator/db/dal_batches.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import String, case
@@ -32,8 +32,8 @@ def _to_batch_item(batch_obj: Batch, username: str | None) -> BatchItem:
     """Convert a Batch row to a BatchItem with empty stats."""
     return BatchItem(
         id=batch_obj.id,
-        created_at=batch_obj.created_at.astimezone(timezone.utc).isoformat(),
-        updated_at=batch_obj.updated_at.astimezone(timezone.utc).isoformat(),
+        created_at=batch_obj.created_at.isoformat() + "Z",
+        updated_at=batch_obj.updated_at.isoformat() + "Z",
         edit_group_id=batch_obj.edit_group_id,
         username=username or "Unknown",
         userid=batch_obj.userid,

--- a/src/curator/db/dal_uploads.py
+++ b/src/curator/db/dal_uploads.py
@@ -57,8 +57,8 @@ def _to_batch_upload_item(u: UploadRequest) -> BatchUploadItem:
         result=u.result,
         error=u.error,
         success=u.success,
-        created_at=u.created_at.isoformat() if u.created_at else None,
-        updated_at=u.updated_at.isoformat() if u.updated_at else None,
+        created_at=u.created_at.isoformat() + "Z" if u.created_at else None,
+        updated_at=u.updated_at.isoformat() + "Z" if u.updated_at else None,
         image_id=u.key,
     )
 
@@ -606,7 +606,7 @@ def get_failed_uploads_grouped(
         row[0]: {
             "batch": {
                 "id": row[0],
-                "createdAt": row[1].isoformat(),
+                "createdAt": row[1].isoformat() + "Z",
                 "editGroupId": row[2],
                 "handler": row[5],
                 "failedCount": row[6],
@@ -635,7 +635,7 @@ def get_failed_uploads_grouped(
                 "handler": upload.handler,
                 "status": upload.status,
                 "error": upload.error.model_dump() if upload.error else None,
-                "createdAt": upload.created_at.isoformat(),
+                "createdAt": upload.created_at.isoformat() + "Z",
                 "errorType": categorize_error(upload.error),
             }
         )

--- a/src/curator/db/models.py
+++ b/src/curator/db/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Union
 
 from pydantic import BaseModel, TypeAdapter
@@ -14,6 +14,12 @@ from curator.asyncapi import (
     Label,
     TitleBlacklistedError,
 )
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time as a naive datetime."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
 
 StructuredError = Union[
     DuplicateError,
@@ -87,9 +93,9 @@ class User(SQLModel, table=True):
 
     userid: str = Field(primary_key=True, max_length=255)
     username: str = Field(index=True, max_length=255)
-    created_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=_utcnow)
     updated_at: datetime = Field(
-        default_factory=datetime.now, sa_column_kwargs={"onupdate": datetime.now}
+        default_factory=_utcnow, sa_column_kwargs={"onupdate": _utcnow}
     )
 
     batches: list["Batch"] = Relationship(back_populates="user")
@@ -115,9 +121,9 @@ class Preset(SQLModel, table=True):
     categories: Optional[str] = Field(default=None, max_length=500)
     exclude_from_date_category: bool = Field(default=False)
     is_default: bool = Field(default=False, index=True)
-    created_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=_utcnow)
     updated_at: datetime = Field(
-        default_factory=datetime.now, sa_column_kwargs={"onupdate": datetime.now}
+        default_factory=_utcnow, sa_column_kwargs={"onupdate": _utcnow}
     )
 
     user: Optional[User] = Relationship(back_populates="presets")
@@ -130,11 +136,11 @@ class Batch(SQLModel, table=True):
     id: int = Field(default=None, primary_key=True)
     userid: str = Field(foreign_key="users.userid", index=True, max_length=255)
     edit_group_id: str | None = Field(default=None, max_length=12)
-    created_at: datetime = Field(default_factory=datetime.now, index=True)
+    created_at: datetime = Field(default_factory=_utcnow, index=True)
     updated_at: datetime = Field(
-        default_factory=datetime.now,
+        default_factory=_utcnow,
         index=True,
-        sa_column_kwargs={"onupdate": datetime.now},
+        sa_column_kwargs={"onupdate": _utcnow},
     )
 
     user: Optional[User] = Relationship(back_populates="batches")
@@ -167,11 +173,11 @@ class UploadRequest(SQLModel, table=True):
     )
     success: Optional[str] = Field(default=None, sa_column=Column(Text))
     celery_task_id: Optional[str] = Field(default=None, max_length=255)
-    created_at: datetime = Field(default_factory=datetime.now, index=True)
+    created_at: datetime = Field(default_factory=_utcnow, index=True)
     updated_at: datetime = Field(
-        default_factory=datetime.now,
+        default_factory=_utcnow,
         index=True,
-        sa_column_kwargs={"onupdate": datetime.now},
+        sa_column_kwargs={"onupdate": _utcnow},
     )
 
     user: Optional[User] = Relationship(

--- a/tests/app/test_dal.py
+++ b/tests/app/test_dal.py
@@ -48,16 +48,12 @@ def test_get_upload_request_by_id_not_found(mocker, mock_session):
 def test_get_batch(mocker, mock_session):
     """Test that get_batch works with integer ID"""
     # Create a mock Batch with proper attributes
-    mock_datetime = mocker.MagicMock()
-    mock_datetime.isoformat.return_value = "2023-01-01T00:00:00"
-    mock_datetime.isoformat.return_value = "2023-01-01T00:00:00"
-
     mock_batch = mocker.MagicMock()
     mock_batch.id = 789
     mock_batch.userid = "user123"
     mock_batch.name = "Test Batch"
-    mock_batch.created_at.astimezone.return_value = mock_datetime
-    mock_batch.updated_at.astimezone.return_value = mock_datetime
+    mock_batch.created_at.isoformat.return_value = "2023-01-01T00:00:00"
+    mock_batch.updated_at.isoformat.return_value = "2023-01-01T00:00:00"
     mock_batch.edit_group_id = None
 
     # Create mock user


### PR DESCRIPTION
All datetime fields sent to the frontend now include the Z suffix (e.g. `2026-05-03T11:40:03Z`). Models updated to use `_utcnow()` (based on `datetime.now(timezone.utc)`) instead of `datetime.now()` to enforce UTC storage regardless of server timezone.