### PR TITLE
fix: omit redundant None args for aliased Pydantic fields to satisfy ty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Redis = Celery **broker** + **result backend**. Redis restart destroys in-flight
 ### SDC Key Mapping Pattern
 - Auto-generated AsyncAPI models use kebab-case aliases (e.g., `entity-type`, `numeric-id`)
 - DAL's `_fix_sdc_keys()` recursively maps snake_case to kebab-case for DB storage
+- **Pydantic aliased fields + ty**: `ty` resolves constructor params by alias, not Python field name — even with `populate_by_name=True`. Omit optional aliased fields instead of passing `field=None`; use alias when explicitly passing.
 
 ### Commons Replica Database
 

--- a/src/curator/mediawiki/sdc_v2.py
+++ b/src/curator/mediawiki/sdc_v2.py
@@ -145,8 +145,6 @@ def _create_quantity_snak(
         datavalue=QuantityDataValue(
             value=DataValueQuantity(
                 amount=f"+{amount}",
-                upper_bound=None,
-                lower_bound=None,
                 unit=f"http://www.wikidata.org/entity/{unit_item_id}",
             )
         ),

--- a/tests/sdc/test_sdc_merge_qualifier_hashes.py
+++ b/tests/sdc/test_sdc_merge_qualifier_hashes.py
@@ -71,8 +71,6 @@ def make_quantity_snak(prop: str, amount: float, unit_id: str) -> QuantityValueS
         datavalue=QuantityDataValue(
             value=DataValueQuantity(
                 amount=f"+{amount}",
-                upper_bound=None,
-                lower_bound=None,
                 unit=f"http://www.wikidata.org/entity/{unit_id}",
             )
         ),

--- a/tests/sdc/test_sdc_merge_snak_equality.py
+++ b/tests/sdc/test_sdc_merge_snak_equality.py
@@ -72,8 +72,6 @@ def make_quantity_snak(prop: str, amount: float, unit_id: str) -> QuantityValueS
         datavalue=QuantityDataValue(
             value=DataValueQuantity(
                 amount=f"+{amount}",
-                upper_bound=None,
-                lower_bound=None,
                 unit=f"http://www.wikidata.org/entity/{unit_id}",
             )
         ),

--- a/tests/sdc/test_sdc_production_parsing.py
+++ b/tests/sdc/test_sdc_production_parsing.py
@@ -72,8 +72,6 @@ def make_quantity_snak(prop: str, amount: float, unit_id: str) -> QuantityValueS
         datavalue=QuantityDataValue(
             value=DataValueQuantity(
                 amount=f"+{amount}",
-                upper_bound=None,
-                lower_bound=None,
                 unit=f"http://www.wikidata.org/entity/{unit_id}",
             )
         ),

--- a/tests/sdc/test_sdc_statement_existing.py
+++ b/tests/sdc/test_sdc_statement_existing.py
@@ -55,8 +55,6 @@ def make_quantity_snak(prop: str, amount: float, unit_id: str) -> QuantityValueS
         datavalue=QuantityDataValue(
             value=DataValueQuantity(
                 amount=f"+{amount}",
-                upper_bound=None,
-                lower_bound=None,
                 unit=f"http://www.wikidata.org/entity/{unit_id}",
             )
         ),


### PR DESCRIPTION
`ty` resolves Pydantic constructor params by alias name, not Python field name — even when `populate_by_name=True`. Passing `upper_bound=None` / `lower_bound=None` to `DataValueQuantity` triggered `unknown-argument` errors because those fields have `alias="upperBound"` / `alias="lowerBound"`. Since both fields default to `None`, the fix is simply to omit them.

Also documents this gotcha in CLAUDE.md.